### PR TITLE
fix: use isomorphic layout effect in `useCookies` to suppress SSR warning

### DIFF
--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -1,10 +1,7 @@
-import { useContext, useEffect, useLayoutEffect, useState, useMemo } from 'react';
+import { useContext, useState, useMemo } from 'react';
 import { Cookie, CookieSetOptions, CookieGetOptions } from 'universal-cookie';
 import CookiesContext from './CookiesContext';
-import { isInBrowser } from './utils';
-
-const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import { useIsomorphicLayoutEffect } from './utils';
 
 export default function useCookies<T extends string, U = { [K in T]?: any }>(
   dependencies?: T[],
@@ -25,11 +22,7 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
 
   const [allCookies, setCookies] = useState(() => cookies.getAll(getOptions));
 
-  const isInBrowserEnv = isInBrowser();
-
   useIsomorphicLayoutEffect(() => {
-    if (!isInBrowserEnv) return;
-
     function onChange() {
       if (!cookies) {
         throw new Error('Missing <CookiesProvider>');
@@ -47,7 +40,7 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
     return () => {
       cookies.removeChangeListener(onChange);
     };
-  }, [cookies, allCookies, isInBrowserEnv]);
+  }, [cookies, allCookies]);
 
   const setCookie = useMemo(() => cookies.set.bind(cookies), [cookies]);
   const removeCookie = useMemo(() => cookies.remove.bind(cookies), [cookies]);

--- a/packages/react-cookie/src/useCookies.tsx
+++ b/packages/react-cookie/src/useCookies.tsx
@@ -1,7 +1,10 @@
-import { useContext, useLayoutEffect, useState, useMemo } from 'react';
+import { useContext, useEffect, useLayoutEffect, useState, useMemo } from 'react';
 import { Cookie, CookieSetOptions, CookieGetOptions } from 'universal-cookie';
 import CookiesContext from './CookiesContext';
 import { isInBrowser } from './utils';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 export default function useCookies<T extends string, U = { [K in T]?: any }>(
   dependencies?: T[],
@@ -24,7 +27,7 @@ export default function useCookies<T extends string, U = { [K in T]?: any }>(
 
   const isInBrowserEnv = isInBrowser();
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!isInBrowserEnv) return;
 
     function onChange() {

--- a/packages/react-cookie/src/utils.ts
+++ b/packages/react-cookie/src/utils.ts
@@ -1,3 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react';
+
 export function isInBrowser() {
   return (
     typeof window !== 'undefined' &&
@@ -5,3 +7,7 @@ export function isInBrowser() {
     typeof window.document.createElement !== 'undefined'
   );
 }
+
+export const useIsomorphicLayoutEffect = isInBrowser()
+  ? useLayoutEffect
+  : useEffect;


### PR DESCRIPTION
## Problem

`useCookies` calls `useLayoutEffect` unconditionally, causing React to emit a `useLayoutEffect does nothing on the server` warning in every SSR-enabled app. The effect body already guards against running server-side with `if (!isInBrowserEnv) return`, so this is purely log noise.

## Fix

Replace `useLayoutEffect` with an isomorphic variant that falls back to `useEffect` on the server — the standard pattern used by Chakra UI, MUI, Framer Motion, etc. No behaviour changes on the client.