### PR TITLE
fix: patch dependency vulnerabilities

### DIFF
--- a/.claude/skills/fix-vulnerabilities/SKILL.md
+++ b/.claude/skills/fix-vulnerabilities/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: fix-vulnerabilities
+description: Triage and fix dependency vulnerabilities in a yarn project. Use when the user asks to fix, address, or patch dependency/dependabot/yarn audit vulnerabilities.
+---
+
+# Fix Vulnerabilities
+
+## 1. Sync main
+
+```bash
+git checkout main && git pull
+```
+
+## 2. Create branch
+
+```bash
+git checkout -b fix/vulnerabilities-$(date +%Y-%m-%d)
+```
+
+## 3. List Dependabot alerts
+
+Use the repo's actual owner/name (don't leave `:owner/:repo`). The patched version lives under `vulnerabilities[].first_patched_version.identifier`.
+
+```bash
+gh api repos/<owner>/<repo>/dependabot/alerts --paginate \
+  -q '.[] | select(.state=="open") | {pkg: .dependency.package.name, severity: .security_advisory.severity, summary: .security_advisory.summary, vulnerable: .security_vulnerability.vulnerable_version_range, patched: .security_advisory.vulnerabilities[0].first_patched_version.identifier, manifest: .dependency.manifest_path}'
+```
+
+Also check code scanning (often catches CI/workflow issues that audit misses):
+
+```bash
+gh api repos/<owner>/<repo>/code-scanning/alerts --paginate -q '.[] | select(.state=="open")'
+```
+
+## 4. Run yarn audit
+
+```bash
+yarn npm audit --recursive --json
+```
+
+Treat **deprecation notices** (e.g. `inflight`, `whatwg-encoding`, "Old versions of glob are not supported") as informational — they have no patched version and can't be "fixed" without replacing the upstream caller. Note them in the PR body and move on.
+
+## 5. Fix in priority order
+
+For each vulnerability, try in order:
+
+1. **Bump the direct dependency.** Check both root `package.json` AND every workspace `package.json` (`packages/*/package.json`) — the vulnerable transitive may be reachable through a workspace. If a direct dep can be bumped to a version whose transitives no longer carry the vuln, do that:
+
+   ```bash
+   yarn up <pkg>@<safe-version>
+   ```
+
+   Always verify against `npm view <pkg> version` — if every direct dep is already at latest and the vuln persists, no direct bump can fix it.
+
+2. **Add a `resolutions` entry** for transitives with no direct-bump path. **Yarn 4 syntax has sharp edges:**
+   - Flat keys (`"pkg": "version"`) override every instance — only use when one safe version works for all callers.
+   - Range-pattern keys **must** use the `npm:` protocol prefix AND match descriptors that actually appear in `yarn.lock`. `"minimatch@^3.0.0": "..."` is silently ignored; `"minimatch@npm:^3.1.1": "..."` works.
+   - Find the real descriptors first:
+     ```bash
+     grep -E '^"<pkg>@' yarn.lock
+     ```
+   - When a package has multiple incompatible major lines in the tree (e.g. minimatch 3.x and 9.x have different APIs), pin each line **separately** — a single flat pin will break callers.
+
+   Example block from this repo:
+
+   ```json
+   "resolutions": {
+     "tar": "^7.5.11",
+     "minimatch@npm:^3.1.1": "^3.1.4",
+     "minimatch@npm:^9.0.4": "^9.0.9"
+   }
+   ```
+
+   Then `yarn install` and confirm the resolution step output mentions the bumped versions — if it doesn't, the pattern didn't match.
+
+3. **No fix available** — leave it and note it in the PR body.
+
+Re-run `yarn npm audit --recursive` after each change.
+
+## 6. Verify
+
+Run the following commands — fix any failure before committing:
+
+```bash
+yarn format
+yarn build
+yarn size
+yarn test
+npx playwright install --with-deps
+npx playwright test
+```
+
+Resolutions can break callers expecting older APIs (especially across major versions). Tests alone aren't enough — build pipelines (rollup, webpack, babel) often hit the bumped transitives at compile time.
+
+**If a bump/resolution breaks the build and the incompatibility can't be reconciled** (caller depends on a removed API, peer-dep conflict between two libs, etc.), **roll back that specific change** — revert the `yarn up` or remove the offending `resolutions` entry, run `yarn install`, and move it to the "Unfixed" section of the PR body with a one-line reason. Do not commit a broken build.
+
+## 7. Commit, push, open PR
+
+Commit with **no co-author trailer**:
+
+```bash
+git add -A
+git commit -m "fix: patch dependency vulnerabilities"
+git push -u origin HEAD
+gh pr create --title "fix: patch dependency vulnerabilities" --body "$(cat <<'EOF'
+## Fixed
+- <pkg>: <old> → <new> (direct bump / resolution)
+
+## Unfixed (no patch available)
+- <pkg> (<severity>): <summary>
+EOF
+)"
+```

--- a/package.json
+++ b/package.json
@@ -66,5 +66,24 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,css,html,json,yml}": "prettier --write"
   },
+  "resolutions": {
+    "tar": "^7.5.11",
+    "ajv@npm:^8.0.0": "^8.18.0",
+    "ajv@npm:^8.9.0": "^8.18.0",
+    "js-yaml@npm:^3.13.1": "^3.14.2",
+    "picomatch@npm:^2.0.4": "^2.3.2",
+    "picomatch@npm:^2.2.1": "^2.3.2",
+    "picomatch@npm:^2.3.1": "^2.3.2",
+    "picomatch@npm:^4.0.2": "^4.0.4",
+    "picomatch@npm:^4.0.3": "^4.0.4",
+    "minimatch@npm:^3.0.4": "^3.1.4",
+    "minimatch@npm:^3.1.1": "^3.1.4",
+    "minimatch@npm:^9.0.4": "^9.0.7",
+    "brace-expansion@npm:^1.1.7": "^1.1.13",
+    "brace-expansion@npm:^2.0.1": "^2.0.3",
+    "glob@npm:^10.2.2": "^10.5.0",
+    "glob@npm:^10.3.7": "^10.5.0",
+    "glob@npm:^10.3.10": "^10.5.0"
+  },
   "packageManager": "yarn@4.7.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,15 +3542,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.9.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
+"ajv@npm:^8.18.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 
@@ -3836,22 +3836,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+"brace-expansion@npm:^1.1.13":
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/b6fdac832bc4e36a753658c9ed052c2e1a2be221763b002df25d1efbf7d21724334e726a6cd5eadc72a4b19ec3efb632d629cc003bc9c62f7af7a7915ffa4385
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.0
+  resolution: "brace-expansion@npm:2.1.0"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
   languageName: node
   linkType: hard
 
@@ -5140,22 +5140,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
-  languageName: node
-  linkType: hard
-
 "glob@npm:^10.5.0":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
@@ -6090,15 +6074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.1
-  resolution: "js-yaml@npm:3.14.1"
+"js-yaml@npm:^3.14.2":
+  version: 3.14.2
+  resolution: "js-yaml@npm:3.14.2"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/6746baaaeac312c4db8e75fa22331d9a04cccb7792d126ed8ce6a0bbcfef0cedaddd0c5098fade53db067c09fe00aa1c957674b4765610a8b06a5a189e46433b
+  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
   languageName: node
   linkType: hard
 
@@ -6484,21 +6468,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+"minimatch@npm:^3.1.4":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  checksum: 10c0/2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+"minimatch@npm:^9.0.7":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -6586,12 +6570,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
+"minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
   languageName: node
   linkType: hard
 
@@ -6940,21 +6924,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+"picomatch@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "picomatch@npm:4.0.2"
-  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.3":
+"picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -8194,17 +8171,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
+"tar@npm:^7.5.11":
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.0.1"
-    mkdirp: "npm:^3.0.1"
+    minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
+  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fixed

Added `resolutions` to root `package.json` to bump vulnerable transitives:

- **tar**: 7.4.3 → ^7.5.11 (high — multiple path traversal / hardlink / race condition CVEs)
- **minimatch** 3.x: → ^3.1.4 (high — ReDoS GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74, GHSA-3ppc-4f35-3m26)
- **minimatch** 9.x: → ^9.0.7 (high — same ReDoS family)
- **glob** 10.x: → ^10.5.0 (high — GHSA-5j98-mcp5-4vw2 command injection in CLI)
- **picomatch** 2.x: → ^2.3.2 (high/moderate — ReDoS, method injection)
- **picomatch** 4.x: → ^4.0.4 (high/moderate — same)
- **ajv** 8.x: → ^8.18.0 (moderate — ReDoS via \$data option)
- **js-yaml** 3.x: → ^3.14.2 (moderate — prototype pollution in merge)
- **brace-expansion** 1.x: → ^1.1.13 (moderate — zero-step sequence hang)
- **brace-expansion** 2.x: → ^2.0.3 (moderate — same)

## Unfixed (no patch available)

Deprecation notices, not security advisories — informational only:

- **glob 10.5.0** (moderate, deprecation): "Old versions of glob are not supported." Security CVE above is fixed; this is just an upstream deprecation.
- **inflight 1.0.6** (moderate, deprecation): unmaintained. Pulled in by `glob@7.2.3` (transitive of `@istanbuljs/load-nyc-config`). No replacement without upstream change.
- **whatwg-encoding 3.1.1** (moderate, deprecation): pulled in by `jsdom@26.1.0`. Upstream-only fix.

## Test plan

- [x] `yarn npm audit --recursive` — only deprecation notices remain
- [x] `yarn format`
- [x] `yarn build`
- [x] `yarn size`
- [x] `yarn test` — 48 passed
- [x] `npx playwright test` — 9 passed