### PR TITLE
fix: drop Node-only types from universal-cookie

### DIFF
--- a/packages/universal-cookie/src/Cookies.ts
+++ b/packages/universal-cookie/src/Cookies.ts
@@ -12,7 +12,7 @@ export default class Cookies {
   private cookies: { [name: string]: Cookie };
   private defaultSetOptions: CookieSetOptions;
   private changeListeners: CookieChangeListener[] = [];
-  private pollingInterval?: NodeJS.Timeout;
+  private pollingInterval?: ReturnType<typeof setInterval>;
 
   private HAS_DOCUMENT_COOKIE: boolean = false;
 

--- a/packages/universal-cookie/src/utils.ts
+++ b/packages/universal-cookie/src/utils.ts
@@ -3,9 +3,9 @@ import { Cookie, CookieGetOptions } from './types';
 
 export function hasDocumentCookie() {
   const testingValue =
-    typeof global === 'undefined'
+    typeof globalThis === 'undefined'
       ? undefined
-      : (global as any).TEST_HAS_DOCUMENT_COOKIE;
+      : (globalThis as any).TEST_HAS_DOCUMENT_COOKIE;
 
   if (typeof testingValue === 'boolean') {
     return testingValue;


### PR DESCRIPTION
Replaces `NodeJS.Timeout` with `ReturnType<typeof setInterval>` and `global` with `globalThis` so the universal-cookie build no longer requires `@types/node`.