### PR TITLE
fix: use git+https format for repository URLs in package.json

### DIFF
--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ItsBenCodes/cookies.git"
+    "url": "git+https://github.com/ItsBenCodes/cookies.git"
   },
   "bugs": "https://github.com/ItsBenCodes/cookies/issues",
   "homepage": "https://github.com/ItsBenCodes/cookies/tree/main/packages/react-cookie/#readme",

--- a/packages/universal-cookie-express/package.json
+++ b/packages/universal-cookie-express/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ItsBenCodes/cookies.git"
+    "url": "git+https://github.com/ItsBenCodes/cookies.git"
   },
   "bugs": "https://github.com/ItsBenCodes/cookies/issues",
   "homepage": "https://github.com/ItsBenCodes/cookies/tree/main/packages/universal-cookie-express#readme",

--- a/packages/universal-cookie-koa/package.json
+++ b/packages/universal-cookie-koa/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ItsBenCodes/cookies.git"
+    "url": "git+https://github.com/ItsBenCodes/cookies.git"
   },
   "bugs": "https://github.com/ItsBenCodes/cookies/issues",
   "homepage": "https://github.com/ItsBenCodes/cookies/tree/main/packages/universal-cookie-koa#readme",

--- a/packages/universal-cookie/package.json
+++ b/packages/universal-cookie/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ItsBenCodes/cookies.git"
+    "url": "git+https://github.com/ItsBenCodes/cookies.git"
   },
   "bugs": "https://github.com/ItsBenCodes/cookies/issues",
   "homepage": "https://github.com/ItsBenCodes/cookies/tree/main/packages/universal-cookie#readme",


### PR DESCRIPTION
## Summary
- Update all `repository.url` fields in package.json files to use the `git+https://` prefix expected by npm

## Test plan
- [x] Lint-staged + tests run on commit