### PR TITLE
chore: add commit and validate skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
   },
   "sandbox": {
     "enabled": true,
-    "autoAllowBashIfSandboxed": true
+    "autoAllowBashIfSandboxed": true,
+    "excludedCommands": ["npx playwright *", "git commit *", "gh *"]
   },
   "attribution": {
     "commit": "",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,13 @@
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,
-    "excludedCommands": ["npx playwright *", "git commit *", "gh *"]
+    "excludedCommands": [
+      "npx playwright *",
+      "git commit *",
+      "gh *",
+      "npm install",
+      "npm install *"
+    ]
   },
   "attribution": {
     "commit": "",

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: commit
+description: Commit staged work, push the branch, and open a PR. Use when wrapping up changes that need to ship.
+disable-model-invocation: true
+---
+
+# Commit
+
+Commit → push → open PR. Never on `main`.
+
+## 1. Stage
+
+Stage only files relevant to this change. Prefer explicit paths over `git add -A` unless every modified file belongs to the change.
+
+## 2. Commit
+
+- Match the repo's commit style (see recent `git log`). Concise, focused on the why.
+- **No co-author trailer.**
+- Never use `--no-verify`. If a hook fails, fix the cause and make a new commit.
+
+```bash
+git commit -m "<message>"
+```
+
+## 3. Push
+
+```bash
+git push -u origin HEAD
+```
+
+## 4. Open PR
+
+Title under 70 chars. Body via HEREDOC. Default base is `main`.
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- ...
+
+## Test plan
+- [ ] ...
+EOF
+)"
+```
+
+Return the PR URL. Use `gh pr merge --auto --squash` only when the caller asks for auto-merge (e.g. release PRs).

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: create-plan
+description: Draft an implementation plan for a feature in .agents/plans. Does not execute the plan. Use when the user asks to plan, design, or scope a feature without building it.
+argument-hint: feature description
+---
+
+# Create Plan
+
+Write a plan to `.agents/plans/`. Do not implement.
+
+## 1. Clarify
+
+Ask questions in batches until the feature is unambiguous. Read the code instead of asking whenever the answer is in the repo. Stop at nitpicks.
+
+## 2. Offer options
+
+Present 2–4 high-level approaches. For each: shape, main upside, main cost. Ask which to take. Wait.
+
+## 3. Write the plan
+
+Save to `.agents/plans/YYYY-MM-DD-<slug>.md` (create the dir if missing). Use this template:
+
+The plan can cover a feature, bug fix, refactor, or technical task. Adapt the user story and acceptance criteria accordingly (e.g., for a refactor, "user" may be a developer; for a bug fix, frame the story around the broken behavior).
+
+```markdown
+# <Title>
+
+## User story
+
+As a <user>, I want <goal> so that <benefit>.
+
+## Description
+
+A few paragraphs explaining what this is, the motivation, the current state, and the desired state. Include enough context that a reader unfamiliar with the work can understand it without external references.
+
+## Acceptance criteria
+
+User-perspective only. No technical terms, file names, or APIs.
+
+- [ ] ...
+
+## Out of scope
+
+- ...
+
+## Implementation details
+
+Architecture, key types, dependencies, relevant patterns, trade-offs.
+
+## Testing strategy
+
+What to cover and how: unit, integration, e2e (Playwright). Note any new fixtures, mocks, or manual verification steps.
+
+## Tasks
+
+- [ ] ...
+- [ ] Run the `validate` skill (must be the last task)
+
+## Open questions
+
+- ...
+```
+
+Tell the user the file path.
+
+## 4. Iterate
+
+Apply requested edits, repeat until approved. Do not implement.

--- a/.claude/skills/execute-plan/SKILL.md
+++ b/.claude/skills/execute-plan/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: execute-plan
+description: Execute an implementation plan. Implements every task, runs validation, commits, and opens a PR. Use when the user asks to execute, implement, or run a plan file.
+argument-hint: path to plan file
+---
+
+# Execute Plan
+
+Implement a plan end-to-end: code the tasks, validate, commit, and open a PR.
+
+## 1. Load the plan
+
+Read the plan file passed in `$ARGUMENTS`. If no path is given, list `.agents/plans/` and ask which one. Re-read the plan whenever you need to refresh context — do not paraphrase from memory.
+
+## 2. Set up the branch
+
+Never commit to `main`. Check the current branch:
+
+- If on `main`, create a new branch named after the plan slug (e.g., `<slug>` from `YYYY-MM-DD-<slug>.md`).
+- If already on a feature branch, stay on it.
+
+## 3. Seed todos
+
+Use TaskCreate to mirror every item from the plan's "Tasks" section as a todo, in order. The final todo must be "Run validation steps" (this should already be the last task in the plan). Do not skip, merge, or reorder tasks.
+
+## 4. Implement
+
+Work through todos one at a time. Mark each completed as soon as it is done — do not batch. If you discover the plan is wrong or incomplete, stop and ask the user before diverging.
+
+## 5. Validate
+
+Use the `validate` skill.
+
+## 6. Commit, push, open PR
+
+Use the `commit` skill. Stage only plan-related files. Default base is `main` (see memory).
+
+## 7. Report
+
+One or two sentences: what shipped, PR link, anything the user should know (skipped items, open questions, follow-ups).

--- a/.claude/skills/fix-vulnerabilities/SKILL.md
+++ b/.claude/skills/fix-vulnerabilities/SKILL.md
@@ -77,35 +77,18 @@ Re-run `npm audit` after each change.
 
 ## 6. Verify
 
-Run the following commands — fix any failure before committing:
-
-```bash
-npm run format
-npm run build
-npm run size
-npm test
-npx playwright install --with-deps
-npx playwright test
-```
-
-Overrides can break callers expecting older APIs (especially across major versions). Tests alone aren't enough — build pipelines (rollup, webpack, babel) often hit the bumped transitives at compile time.
+Use the `validate` skill. Overrides can break callers expecting older APIs (especially across major versions). Tests alone aren't enough — build pipelines (rollup, webpack, babel) often hit the bumped transitives at compile time.
 
 **If a bump/override breaks the build and the incompatibility can't be reconciled** (caller depends on a removed API, peer-dep conflict between two libs, etc.), **roll back that specific change** — revert the `npm install` or remove the offending `overrides` entry, run `npm install`, and move it to the "Unfixed" section of the PR body with a one-line reason. Do not commit a broken build.
 
 ## 7. Commit, push, open PR
 
-Commit with **no co-author trailer**:
+Use the `commit` skill with title `fix: patch dependency vulnerabilities` and body:
 
-```bash
-git add -A
-git commit -m "fix: patch dependency vulnerabilities"
-git push -u origin HEAD
-gh pr create --title "fix: patch dependency vulnerabilities" --body "$(cat <<'EOF'
+```
 ## Fixed
 - <pkg>: <old> → <new> (direct bump / override)
 
 ## Unfixed (no patch available)
 - <pkg> (<severity>): <summary>
-EOF
-)"
 ```

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -89,17 +89,16 @@ Verify with `grep -H '"version"' packages/*/package.json`.
 
 ## 7. Commit, push, open PR with auto-merge
 
-Commit with **no co-author trailer**. Match prior style (`Bump to vX.Y.Z`). Build a PR body that lists each bumped package:
+Use the `commit` skill. Stage only `packages/*/package.json`. Title `Bump to v$RELEASE_VERSION`. Body lists each bumped package:
+
+```
+Release v$RELEASE_VERSION
+
+- <pkg> -> <new-version>
+```
+
+After PR is open, enable auto-merge:
 
 ```bash
-BODY="Release v$RELEASE_VERSION"$'\n\n'
-for pkg in "${CHANGED[@]}"; do
-  BODY+="- $pkg -> ${NEW_VERSIONS[$pkg]}"$'\n'
-done
-
-git add packages/*/package.json
-git commit -m "Bump to v$RELEASE_VERSION"
-git push -u origin HEAD
-gh pr create --title "Bump to v$RELEASE_VERSION" --body "$BODY"
 gh pr merge --auto --squash
 ```

--- a/.claude/skills/retrospective/SKILL.md
+++ b/.claude/skills/retrospective/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: retrospective
+description: Analyze past Claude Code session(s) for mistakes and propose targeted improvements. Use when the user asks for a retrospective, post-mortem, or session review. Outputs concise findings plus suggested edits to CLAUDE.md (general lessons) or new/updated skills (specific workflows).
+argument-hint: '[N days] [extra context]'
+---
+
+# Retrospective
+
+Review session transcripts, list mistakes, propose improvements.
+
+## 1. Resolve scope
+
+Parse `$ARGUMENTS`:
+
+- empty → **current session** — analyze from your existing conversation context. Do **not** read any jsonl file; the conversation is already loaded.
+- contains a number + `d`/`day(s)` → past sessions modified within that many days. Read jsonl files from `~/.claude/projects/<encoded-cwd>/`:
+  ```bash
+  SESSION_DIR=~/.claude/projects/$(pwd | sed 's|/|-|g')
+  find "$SESSION_DIR" -name '*.jsonl' -mtime -N
+  ```
+- remaining text → extra focus/context to bias the analysis (e.g. "focus on test failures")
+
+## 2. Analyze
+
+**Current session:** scan your own conversation context. Extract user corrections, retried tool calls, reverts, "no"/"don't"/"stop", failed builds/tests, repeated identical commands, dead-end paths.
+
+**Past sessions (N days):** spawn one `Explore` subagent per jsonl **in parallel** (single message, multiple Agent calls). Brief each:
+
+> Read `<path>`. List only the mistakes Claude made: user corrections, wrong assumptions, repeated failures, wasted tool calls, friction points. One bullet each, ≤15 words. No fixes, no praise. Under 200 words.
+
+Then reconcile: dedupe, group by theme, keep frequency counts.
+
+## 3. Report
+
+Output to the user in this shape (no preamble):
+
+```
+## Mistakes
+- <mistake> (×N)
+- ...
+
+## Improvements
+**CLAUDE.md** (general, always-on):
+- <rule> — <one-line why>
+
+**Skill: <name>** (specific workflow):
+- Trigger: <when to invoke>
+- Body: <2-3 bullet behavior>
+
+## Apply?
+```
+
+Routing rule:
+
+- **CLAUDE.md** = always-relevant rules (style, conventions, repo invariants).
+- **Skill** = workflow that fires on a specific trigger (slash command, task type).
+
+Wait for confirmation before editing CLAUDE.md or creating skill files.
+
+## 4. Apply (on confirmation)
+
+- CLAUDE.md edits: append/modify in place, keep terse.
+- New skill: write `.claude/skills/<name>/SKILL.md` with frontmatter (`name`, `description`, optional `argument-hint`).
+
+Stop. Do not auto-commit.

--- a/.claude/skills/upgrade-dependencies/SKILL.md
+++ b/.claude/skills/upgrade-dependencies/SKILL.md
@@ -59,33 +59,18 @@ Remove any `overrides` entries that are now redundant (the direct dep already ca
 
 ## 6. Verify
 
-Run after every group; fix failures before moving on:
-
-```bash
-npm run format
-npm run build
-npm run size
-npm test
-npx playwright install --with-deps
-npx playwright test
-```
+Use the `validate` skill after every group; fix failures before moving on.
 
 **If a major bump breaks the build and the migration is non-trivial**, roll back that specific upgrade (`npm install <pkg>@<previous>`), note it in the PR body under "Deferred", and keep moving. Do not commit a broken build.
 
 ## 7. Commit, push, open PR
 
-Commit with **no co-author trailer**:
+Use the `commit` skill with title `chore: upgrade dependencies` and body:
 
-```bash
-git add -A
-git commit -m "chore: upgrade dependencies"
-git push -u origin HEAD
-gh pr create --title "chore: upgrade dependencies" --body "$(cat <<'EOF'
+```
 ## Upgraded
 - <pkg>: <old> → <new>
 
 ## Deferred (breaking, needs follow-up)
 - <pkg> <old> → <new>: <reason>
-EOF
-)"
 ```

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -12,7 +12,7 @@ npm run format
 npm run build
 npm run size
 npm test
-npx playwright install --with-deps
+npx playwright install
 npx playwright test
 ```
 

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: validate
+description: Run the repo's full validation suite (format, build, size, tests, e2e). Invoke after any important change — finishing a feature, fix, refactor, or dependency bump — and always before committing.
+---
+
+# Validate
+
+Run every step.
+
+```bash
+npm run format
+npm run build
+npm run size
+npm test
+npx playwright install --with-deps
+npx playwright test
+```
+
+If a step fails, fix the cause and **re-run the full suite from the top** — earlier steps may now produce different output (formatting, generated files, etc.). Repeat until a clean pass with no intervening changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-Run `npm` and `git commit` commands with `dangerouslyDisableSandbox: true` — they need network and GPG access.


### PR DESCRIPTION
## Summary

- Add `commit` skill: stage → commit → push → open PR (no co-author trailer, no `--no-verify`).
- Add `validate` skill: full repo validation suite, re-run from the top after any fix.
- Refactor `execute-plan`, `create-plan`, `fix-vulnerabilities`, `upgrade-dependencies`, `prepare-release` to defer to the new skills instead of inlining the same steps.
- Track previously untracked `create-plan`, `execute-plan`, `retrospective` skill dirs.
- Replace top-level `CLAUDE.md` sandbox note with an `excludedCommands` entry in `.claude/settings.json`.

## Test plan

- [ ] Invoke `/commit` and confirm it follows the new skill steps
- [ ] Invoke `/validate` and confirm all steps run
- [ ] Skim updated skill files for terseness