### PR TITLE
chore: exclude git tag from sandbox and require tag message on release

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
     "excludedCommands": [
       "npx playwright *",
       "git commit *",
+      "git tag *",
       "gh *",
       "npm install",
       "npm install *"

--- a/.claude/skills/publish-release/SKILL.md
+++ b/.claude/skills/publish-release/SKILL.md
@@ -36,8 +36,10 @@ git rev-parse "v$VERSION" >/dev/null 2>&1 && { echo "Tag v$VERSION already exist
 
 ## 3. Tag, push, release
 
+Always create an annotated tag with a message (some local configs enable `tag.gpgsign`, which makes a plain `git tag NAME` fail without a message):
+
 ```bash
-git tag "v$VERSION"
+git tag -a "v$VERSION" -m "v$VERSION"
 git push origin "v$VERSION"
 gh release create "v$VERSION" --title "v$VERSION" --generate-notes
 ```


### PR DESCRIPTION
## Summary
- Add `git tag *` to `.claude/settings.json` `sandbox.excludedCommands` so signed tags can reach gpg-agent without retrying outside the sandbox.
- Update the `publish-release` skill to always create an annotated tag with `-a -m` (handles configs that enable `tag.gpgsign`).

## Test plan
- [ ] Next release: `git tag -a vX.Y.Z -m vX.Y.Z` runs without sandbox retry.