### PR TITLE
build: generate esm/index.d.mts for all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "prettier": "^3.8.1",
         "rimraf": "^6.1.3",
         "rollup": "^4.60.1",
+        "rollup-plugin-dts": "^6.2.1",
         "size-limit": "^12.0.1",
         "tslib": "^2.8.1",
         "typescript": "^6.0.2"
@@ -9981,6 +9982,32 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.2",
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
+      "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "convert-source-map": "^2.0.0",
+        "magic-string": "^0.30.21"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.29.0"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0 || ^6.0"
       }
     },
     "node_modules/router": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "prettier": "^3.8.1",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.1",
+    "rollup-plugin-dts": "^6.2.1",
     "size-limit": "^12.0.1",
     "tslib": "^2.8.1",
     "typescript": "^6.0.2"

--- a/packages/react-cookie/package.json
+++ b/packages/react-cookie/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./esm/index.d.ts",
+        "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
       "require": {

--- a/packages/react-cookie/rollup.config.mjs
+++ b/packages/react-cookie/rollup.config.mjs
@@ -4,6 +4,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import babel from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 
 const external = ['react', 'universal-cookie'];
 const globals = {
@@ -19,7 +20,11 @@ export default [
       format: 'esm',
       entryFileNames: '[name].mjs',
     },
-    plugins: [resolve(), commonjs(), typescript({ outDir: './esm' })],
+    plugins: [
+      resolve(),
+      commonjs(),
+      typescript({ outDir: './esm', declaration: false }),
+    ],
     external,
   },
   {
@@ -72,5 +77,11 @@ export default [
       terser(),
     ],
     external,
+  },
+  {
+    input: 'src/index.ts',
+    output: { file: 'esm/index.d.mts', format: 'esm' },
+    external: ['react', 'universal-cookie', 'hoist-non-react-statics'],
+    plugins: [dts()],
   },
 ];

--- a/packages/universal-cookie-express/package.json
+++ b/packages/universal-cookie-express/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./esm/index.d.ts",
+        "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
       "require": {

--- a/packages/universal-cookie-express/rollup.config.mjs
+++ b/packages/universal-cookie-express/rollup.config.mjs
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import babel from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 
 const external = ['react', 'universal-cookie'];
 const globals = {
@@ -15,7 +16,7 @@ export default [
       format: 'esm',
       entryFileNames: '[name].mjs',
     },
-    plugins: [typescript({ outDir: './esm' })],
+    plugins: [typescript({ outDir: './esm', declaration: false })],
     external,
   },
   {
@@ -29,5 +30,11 @@ export default [
       babel({ babelHelpers: 'bundled' }),
     ],
     external,
+  },
+  {
+    input: 'src/index.ts',
+    output: { file: 'esm/index.d.mts', format: 'esm' },
+    external: ['universal-cookie', 'express'],
+    plugins: [dts()],
   },
 ];

--- a/packages/universal-cookie-koa/package.json
+++ b/packages/universal-cookie-koa/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./esm/index.d.ts",
+        "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
       "require": {

--- a/packages/universal-cookie-koa/rollup.config.mjs
+++ b/packages/universal-cookie-koa/rollup.config.mjs
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import babel from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 
 const external = ['react', 'universal-cookie'];
 const globals = {
@@ -15,7 +16,7 @@ export default [
       format: 'esm',
       entryFileNames: '[name].mjs',
     },
-    plugins: [typescript({ outDir: './esm' })],
+    plugins: [typescript({ outDir: './esm', declaration: false })],
     external,
   },
   {
@@ -29,5 +30,11 @@ export default [
       babel({ babelHelpers: 'bundled' }),
     ],
     external,
+  },
+  {
+    input: 'src/index.ts',
+    output: { file: 'esm/index.d.mts', format: 'esm' },
+    external: ['universal-cookie', 'koa'],
+    plugins: [dts()],
   },
 ];

--- a/packages/universal-cookie/package.json
+++ b/packages/universal-cookie/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./esm/index.d.ts",
+        "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
       },
       "require": {

--- a/packages/universal-cookie/rollup.config.mjs
+++ b/packages/universal-cookie/rollup.config.mjs
@@ -3,6 +3,7 @@ import terser from '@rollup/plugin-terser';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import babel from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 
 export default [
   {
@@ -12,7 +13,11 @@ export default [
       format: 'esm',
       entryFileNames: '[name].mjs',
     },
-    plugins: [resolve(), commonjs(), typescript({ outDir: './esm' })],
+    plugins: [
+      resolve(),
+      commonjs(),
+      typescript({ outDir: './esm', declaration: false }),
+    ],
     external: [], // cookie library is not ESM compatible so we transform it
   },
   {
@@ -46,5 +51,11 @@ export default [
     },
     plugins: [resolve(), commonjs(), typescript({ outDir: './umd' }), terser()],
     external: [], // cookie library is not UMD compatible so we transform it
+  },
+  {
+    input: 'src/index.ts',
+    output: { file: 'esm/index.d.mts', format: 'esm' },
+    external: ['cookie'],
+    plugins: [dts()],
   },
 ];


### PR DESCRIPTION
Use rollup-plugin-dts to emit a single bundled .d.mts declaration file for the ESM output of each package.

Fixes package.json exports "types" condition for ESM consumers using moduleResolution: nodenext/bundler.

Fixes https://github.com/ItsBenCodes/cookies/issues/962